### PR TITLE
[29] Create JSONDatabase and ButtonCount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 button.json
+testButton.json
 errors.log
 .*.swp
 .*.swo

--- a/jsonDatabase/READEME.md
+++ b/jsonDatabase/READEME.md
@@ -1,0 +1,3 @@
+## jsonDatabase
+This "database" is simply a bunch of json objects as "tables".
+This folder will be deleted when the sql refactor is complete.

--- a/src/commands/button.ts
+++ b/src/commands/button.ts
@@ -23,18 +23,18 @@ class ButtonCommand extends CommandBase implements ButtonCommand {
   }
 
   getNewButtonCount(user: any) : number {
-    const currentCount = JSON.parse(fs.readFileSync('./button.json').toString())[user]
+    const currentCount = JSON.parse(fs.readFileSync('./jsonDatabase/button.json').toString())[user]
     return currentCount === undefined ? 1 : currentCount + 1
   }
 
   updateButtonJson(user: any, newNumber: any) {
     // path is relative to pwd
     // TODO Lean on something more robust
-    const rawData = fs.readFileSync('./button.json').toString()
+    const rawData = fs.readFileSync('./jsonDatabase/button.json').toString()
     let buttonScores = JSON.parse(rawData)
     buttonScores[user] = newNumber
     const newRawData = JSON.stringify(buttonScores)
-    fs.writeFileSync('./button.json', newRawData)
+    fs.writeFileSync('./jsonDatabase/button.json', newRawData)
   }
 
   execute(bot: SlackBot) {

--- a/src/db/databaseInterface.ts
+++ b/src/db/databaseInterface.ts
@@ -2,7 +2,6 @@ interface Database {
   databasePath: string;
   getDb: () => any;
   getRowFromId: (tableName: string, id: number) => any;
-  save: () => void;
   insertRow: (row: {[key: string]: any}) => void;
   updateRow: (row: {[key: string]: any}) => void;
   [others: string]: any;

--- a/src/db/databaseInterface.ts
+++ b/src/db/databaseInterface.ts
@@ -3,7 +3,7 @@ interface Database {
   getDb: () => any;
   getRowFromId: (tableName: string, id: number) => any;
   save: () => void;
-  insertRow: () => void;
+  insertRow: (row: {[key: string]: any}) => void;
   updateRow: () => void;
   [others: string]: any;
 }

--- a/src/db/databaseInterface.ts
+++ b/src/db/databaseInterface.ts
@@ -1,0 +1,10 @@
+interface Database {
+  save: () => void;
+  databasePath: string;
+  // getDb: () => any;
+  // getRowFromId: (number: id) => {};
+  // insertRow: () => void;
+  // updateRow: () => void;
+}
+
+export default Database

--- a/src/db/databaseInterface.ts
+++ b/src/db/databaseInterface.ts
@@ -1,10 +1,11 @@
 interface Database {
-  save: () => void;
   databasePath: string;
-  // getDb: () => any;
-  // getRowFromId: (number: id) => {};
-  // insertRow: () => void;
-  // updateRow: () => void;
+  getDb: () => any;
+  getRowFromId: (tableName: string, id: number) => any;
+  save: () => void;
+  insertRow: () => void;
+  updateRow: () => void;
+  [others: string]: any;
 }
 
 export default Database

--- a/src/db/databaseInterface.ts
+++ b/src/db/databaseInterface.ts
@@ -4,7 +4,7 @@ interface Database {
   getRowFromId: (tableName: string, id: number) => any;
   save: () => void;
   insertRow: (row: {[key: string]: any}) => void;
-  updateRow: () => void;
+  updateRow: (row: {[key: string]: any}) => void;
   [others: string]: any;
 }
 

--- a/src/db/jsonDatabase.spec.ts
+++ b/src/db/jsonDatabase.spec.ts
@@ -1,10 +1,43 @@
 import JSONDatabase from './jsonDatabase'
+import * as fs from 'fs'
+
+const TEST_DB_PATH = './jsonDatabase/testButton.json'
+const USER_SLACK_ID = 'ABC123'
+const BUTTON_COUNT = 2
+
+beforeAll(() => {
+  JSONDatabase.databasePath = TEST_DB_PATH
+  setupDb()
+})
+
+afterAll(() => {
+  teardownDb()
+})
+
+const setupDb = async () => {
+  const testData = JSON.stringify({
+    [USER_SLACK_ID]: BUTTON_COUNT
+  });
+  fs.writeFileSync('./jsonDatabase/testButton.json', testData)
+}
+
+const teardownDb = async () => {
+  fs.writeFileSync('./jsonDatabase/testButton.json', JSON.stringify({}))
+}
 
 describe('JSONDatabase', () => {
   it('should exist', () => {
     expect(typeof JSONDatabase).toBe('object')
   })
 
-  describe('save()', () => {
+  describe('getRowFromUserSlackId', () => {
+    it('should exist', () => {
+      expect(typeof JSONDatabase.getRowFromUserSlackId).toBe('function')
+    })
+    it('should read a row from the db', async () => {
+      const expectedRow = { [USER_SLACK_ID]: BUTTON_COUNT }
+      const actualRow = await JSONDatabase.getRowFromUserSlackId(USER_SLACK_ID)
+      expect(actualRow[USER_SLACK_ID]).toBe(expectedRow[USER_SLACK_ID])
+    })
   })
 })

--- a/src/db/jsonDatabase.spec.ts
+++ b/src/db/jsonDatabase.spec.ts
@@ -1,0 +1,10 @@
+import JSONDatabase from './jsonDatabase'
+
+describe('JSONDatabase', () => {
+  it('should exist', () => {
+    expect(typeof JSONDatabase).toBe('object')
+  })
+
+  describe('save()', () => {
+  })
+})

--- a/src/db/jsonDatabase.spec.ts
+++ b/src/db/jsonDatabase.spec.ts
@@ -42,7 +42,7 @@ describe('JSONDatabase', () => {
   })
 
   describe('insertRow', () => {
-    it('should add an entry to the testButton json', async () => {
+    it('should add an entry to testButton.json', async () => {
       const NEW_SLACK_ID = 'XYZ789'
       const NEW_COUNT = 9001
       const inputRow = { [NEW_SLACK_ID]: NEW_COUNT }
@@ -51,6 +51,17 @@ describe('JSONDatabase', () => {
 
       const actualRow = await JSONDatabase.getRowFromUserSlackId(NEW_SLACK_ID)
       expect(actualRow[NEW_SLACK_ID]).toBe(inputRow[NEW_SLACK_ID])
+    })
+  })
+
+  describe('updateRow', () => {
+    it('should update an entry in testButton.json', async () => {
+      const inputRow = {[USER_SLACK_ID]: BUTTON_COUNT + 1}
+
+      await JSONDatabase.updateRow(inputRow)
+      const actualRow = await JSONDatabase.getRowFromUserSlackId(USER_SLACK_ID)
+
+      expect(actualRow[USER_SLACK_ID]).toBe(inputRow[USER_SLACK_ID])
     })
   })
 })

--- a/src/db/jsonDatabase.spec.ts
+++ b/src/db/jsonDatabase.spec.ts
@@ -5,12 +5,12 @@ const TEST_DB_PATH = './jsonDatabase/testButton.json'
 const USER_SLACK_ID = 'ABC123'
 const BUTTON_COUNT = 2
 
-beforeAll(() => {
+beforeEach(() => {
   JSONDatabase.databasePath = TEST_DB_PATH
   setupDb()
 })
 
-afterAll(() => {
+afterEach(() => {
   teardownDb()
 })
 
@@ -18,11 +18,11 @@ const setupDb = async () => {
   const testData = JSON.stringify({
     [USER_SLACK_ID]: BUTTON_COUNT
   });
-  fs.writeFileSync('./jsonDatabase/testButton.json', testData)
+  await fs.writeFileSync('./jsonDatabase/testButton.json', testData)
 }
 
 const teardownDb = async () => {
-  fs.writeFileSync('./jsonDatabase/testButton.json', JSON.stringify({}))
+  await fs.writeFileSync('./jsonDatabase/testButton.json', JSON.stringify({}))
 }
 
 describe('JSONDatabase', () => {
@@ -38,6 +38,19 @@ describe('JSONDatabase', () => {
       const expectedRow = { [USER_SLACK_ID]: BUTTON_COUNT }
       const actualRow = await JSONDatabase.getRowFromUserSlackId(USER_SLACK_ID)
       expect(actualRow[USER_SLACK_ID]).toBe(expectedRow[USER_SLACK_ID])
+    })
+  })
+
+  describe('insertRow', () => {
+    it('should add an entry to the testButton json', async () => {
+      const NEW_SLACK_ID = 'XYZ789'
+      const NEW_COUNT = 9001
+      const inputRow = { [NEW_SLACK_ID]: NEW_COUNT }
+
+      await JSONDatabase.insertRow(inputRow)
+
+      const actualRow = await JSONDatabase.getRowFromUserSlackId(NEW_SLACK_ID)
+      expect(actualRow[NEW_SLACK_ID]).toBe(inputRow[NEW_SLACK_ID])
     })
   })
 })

--- a/src/db/jsonDatabase.ts
+++ b/src/db/jsonDatabase.ts
@@ -14,7 +14,6 @@ const JSONDatabase: Database = {
 
     return row
   },
-  save: () => {},
   insertRow: async function(row: {[key: string]: any}) {
     const rawData: string | undefined = await fs.readFileSync(this.databasePath).toString()
     let buttonScores = JSON.parse(rawData)

--- a/src/db/jsonDatabase.ts
+++ b/src/db/jsonDatabase.ts
@@ -24,7 +24,9 @@ const JSONDatabase: Database = {
     const newRawData = JSON.stringify(buttonScores)
     await fs.writeFileSync(this.databasePath, newRawData)
   },
-  updateRow: () => {},
+  updateRow: async function(row: {[key: string]: any}) {
+    await this.insertRow(row)
+  },
 }
 
 export default JSONDatabase

--- a/src/db/jsonDatabase.ts
+++ b/src/db/jsonDatabase.ts
@@ -10,12 +10,20 @@ const JSONDatabase: Database = {
   },
   getRowFromUserSlackId: async function(userSlackId: string) {
     const rawData = await fs.readFileSync(this.databasePath)
-    const row = JSON.parse(rawData)
+    const row = JSON.parse(rawData.toString())
 
     return row
   },
   save: () => {},
-  insertRow: () => {},
+  insertRow: async function(row: {[key: string]: any}) {
+    const rawData: string | undefined = await fs.readFileSync(this.databasePath).toString()
+    let buttonScores = JSON.parse(rawData)
+    const user = Object.keys(row)[0]
+    const count = row[user]
+    buttonScores[user] = count
+    const newRawData = JSON.stringify(buttonScores)
+    await fs.writeFileSync(this.databasePath, newRawData)
+  },
   updateRow: () => {},
 }
 

--- a/src/db/jsonDatabase.ts
+++ b/src/db/jsonDatabase.ts
@@ -1,11 +1,18 @@
 import Database from './databaseInterface'
-//import * as fs from 'fs'
+// @ts-ignore
+import * as fs from 'fs'
 
 const JSONDatabase: Database = {
   databasePath: './button.json',
   getDb: () => {},
   getRowFromId: (tableName: string, id: number) => {
     return {}
+  },
+  getRowFromUserSlackId: async function(userSlackId: string) {
+    const rawData = await fs.readFileSync(this.databasePath)
+    const row = JSON.parse(rawData)
+
+    return row
   },
   save: () => {},
   insertRow: () => {},

--- a/src/db/jsonDatabase.ts
+++ b/src/db/jsonDatabase.ts
@@ -1,0 +1,11 @@
+import Database from './databaseInterface'
+//import * as fs from 'fs'
+
+const JSONDatabase: Database = {
+  databasePath: './button.json',
+
+  save: () => {
+  }
+}
+
+export default JSONDatabase

--- a/src/db/jsonDatabase.ts
+++ b/src/db/jsonDatabase.ts
@@ -3,9 +3,13 @@ import Database from './databaseInterface'
 
 const JSONDatabase: Database = {
   databasePath: './button.json',
-
-  save: () => {
-  }
+  getDb: () => {},
+  getRowFromId: (tableName: string, id: number) => {
+    return {}
+  },
+  save: () => {},
+  insertRow: () => {},
+  updateRow: () => {},
 }
 
 export default JSONDatabase

--- a/src/db/mockDatabase.ts
+++ b/src/db/mockDatabase.ts
@@ -2,7 +2,13 @@ import Database from './databaseInterface'
 
 const mockDatabase: Database = {
   databasePath: '',
+  getDb: () => {},
+  getRowFromId: (tableName: string, id: number) => {
+    return {}
+  },
   save: () => {},
+  insertRow: () => {},
+  updateRow: () => {},
 }
 
 export default mockDatabase

--- a/src/db/mockDatabase.ts
+++ b/src/db/mockDatabase.ts
@@ -1,0 +1,8 @@
+import Database from './databaseInterface'
+
+const mockDatabase: Database = {
+  databasePath: '',
+  save: () => {},
+}
+
+export default mockDatabase

--- a/src/models/buttonCount.spec.ts
+++ b/src/models/buttonCount.spec.ts
@@ -1,8 +1,8 @@
 import ButtonCount from './buttonCount'
+import mockDatabase from '../db/mockDatabase'
 
 const USER_SLACK_ID = 'ABC'
 const COUNT = 5
-const mockDatabase = {}
 
 describe('ButtonCount', () => {
   it('should exist', () => {

--- a/src/models/buttonCount.spec.ts
+++ b/src/models/buttonCount.spec.ts
@@ -1,0 +1,53 @@
+import ButtonCount from './buttonCount'
+
+const USER_SLACK_ID = 'ABC'
+const COUNT = 5
+const mockDatabase = {}
+
+describe('ButtonCount', () => {
+  it('should exist', () => {
+    expect(typeof ButtonCount).toBe('function')
+  })
+
+  describe('constructor', () => {
+    it('should take a database as an argument', () => {
+      const instance = new ButtonCount(undefined, undefined, mockDatabase)
+      expect(instance.database).toBe(mockDatabase)
+    })
+
+    it('should take userSlackId as an argument', () => {
+      const instance = new ButtonCount(USER_SLACK_ID)
+      expect(instance.userSlackId).toBe(USER_SLACK_ID)
+    })
+
+    it('should set default userSlackId to an empty string', () => {
+      const instance = new ButtonCount(undefined)
+      expect(instance.userSlackId).toBe('')
+    })
+
+    it('should take count as an argument', () => {
+      const instance = new ButtonCount(USER_SLACK_ID, COUNT)
+      expect(instance.count).toBe(COUNT)
+    })
+
+    it('should set default count to 0', () => {
+      const instance = new ButtonCount(USER_SLACK_ID, undefined)
+      expect(instance.count).toBe(0)
+    })
+  })
+
+  describe('increment()', () => {
+    it('should increase count by one', () => {
+      const instance = new ButtonCount()
+      instance.increment()
+      expect(instance.count).toBe(1)
+    })
+  })
+
+  describe('static getFromUserSlackId', () => {
+    it('should return an instance from the db', () => {
+      const instance = new ButtonCount(undefined, undefined, mockDatabase)
+      expect(instance.database).toBe(mockDatabase)
+    })
+  })
+})

--- a/src/models/buttonCount.ts
+++ b/src/models/buttonCount.ts
@@ -1,14 +1,12 @@
-interface Database {
-}
-
-const JSONDatabase: Database  = {}
+import Database from '../db/databaseInterface'
+import _JSONDatabase from '../db/jsonDatabase'
 
 class ButtonCount {
   userSlackId: string
   count: number
   database: Database
 
-  constructor(userSlackId = '', count = 0, database = JSONDatabase) {
+  constructor(userSlackId = '', count = 0, database: Database = _JSONDatabase) {
     this.userSlackId = userSlackId
     this.count = count
     this.database = database
@@ -17,7 +15,6 @@ class ButtonCount {
   increment() : void {
     this.count++
   }
-
 }
 
 export default ButtonCount

--- a/src/models/buttonCount.ts
+++ b/src/models/buttonCount.ts
@@ -1,0 +1,23 @@
+interface Database {
+}
+
+const JSONDatabase: Database  = {}
+
+class ButtonCount {
+  userSlackId: string
+  count: number
+  database: Database
+
+  constructor(userSlackId = '', count = 0, database = JSONDatabase) {
+    this.userSlackId = userSlackId
+    this.count = count
+    this.database = database
+  }
+
+  increment() : void {
+    this.count++
+  }
+
+}
+
+export default ButtonCount


### PR DESCRIPTION
## Changes
This change creates the following:
* A new interface for objects that interact with the database
* A JSONDatabase object
* A model representing ButtonCount

## Context
This PR is part of a broader project to migrate away from JSON towards SQL. Why improve the JSON implementation when we are going to replace it anyway? This will make the transition easier, because the steps will be smaller.

closes #29
closes #30 
closes #31 

## How to review
I was on a roll and mixed these three all together, but I definitely should have split #30 out to a separate PR.
There are two halves to consider:
* A
  * src/db/mockDatabase.ts
  * src/models/buttonCount.spec.ts
  * src/models/buttonCount.ts
* B
  * src/db/databaseInterface.ts
  * src/db/jsonDatabase.spec.ts
  * src/db/jsonDatabase.ts